### PR TITLE
use the good representation for encrypted epub and add compression info

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -19,7 +19,7 @@ var decoderList []List
 func Decode(publication models.Publication, link models.Link, reader io.ReadSeeker) (io.ReadSeeker, error) {
 
 	for _, decoderFunc := range decoderList {
-		if link.CryptAlgorithm == decoderFunc.decoderAlgorithm {
+		if link.Properties != nil && link.Properties.Encrypted != nil && link.Properties.Encrypted.Algorithm == decoderFunc.decoderAlgorithm {
 			return decoderFunc.decoder(publication, link, reader)
 		}
 	}
@@ -30,7 +30,7 @@ func Decode(publication models.Publication, link models.Link, reader io.ReadSeek
 // NeedToDecode check if there a decoder for this resource
 func NeedToDecode(publication models.Publication, link models.Link) bool {
 	for _, decoderFunc := range decoderList {
-		if link.CryptAlgorithm == decoderFunc.decoderAlgorithm {
+		if link.Properties != nil && link.Properties.Encrypted != nil && link.Properties.Encrypted.Algorithm == decoderFunc.decoderAlgorithm {
 			return true
 		}
 	}

--- a/models/metadata.go
+++ b/models/metadata.go
@@ -56,13 +56,23 @@ type Contributor struct {
 // Properties object use to link properties
 // Use also in Rendition for fxl
 type Properties struct {
-	Contains     []string `json:"contains,omitempty"`
-	Layout       string   `json:"layout,omitempty"`
-	MediaOverlay string   `json:"media-overlay,omitempty"`
-	Orientation  string   `json:"orientation,omitempty"`
-	Overflow     string   `json:"overflow,omitempty"`
-	Page         string   `json:"page,omitempty"`
-	Spread       string   `json:"spread,omitempty"`
+	Contains     []string   `json:"contains,omitempty"`
+	Layout       string     `json:"layout,omitempty"`
+	MediaOverlay string     `json:"media-overlay,omitempty"`
+	Orientation  string     `json:"orientation,omitempty"`
+	Overflow     string     `json:"overflow,omitempty"`
+	Page         string     `json:"page,omitempty"`
+	Spread       string     `json:"spread,omitempty"`
+	Encrypted    *Encrypted `json:"encrypted,omitempty"`
+}
+
+// Encrypted contains metadata from encryption xml
+type Encrypted struct {
+	Scheme    string `json:"scheme,omitempty"`
+	Profile   string `json:"profile,omitempty"`
+	Algorithm string `json:"algorithm,omitempty"`
+	Package   string `json:"package,omitempty"`
+	Size      int    `json:"size,omitempty"`
 }
 
 // Subject as based on EPUB 3.1 and WePpub

--- a/models/publication.go
+++ b/models/publication.go
@@ -34,17 +34,16 @@ type Internal struct {
 
 // Link object used in collections and links
 type Link struct {
-	Href           string      `json:"href"`
-	TypeLink       string      `json:"type,omitempty"`
-	Rel            []string    `json:"rel,omitempty"`
-	Height         int         `json:"height,omitempty"`
-	Width          int         `json:"width,omitempty"`
-	Title          string      `json:"title,omitempty"`
-	Properties     *Properties `json:"properties,omitempty"`
-	Duration       string      `json:"duration,omitempty"`
-	Templated      bool        `json:"templated,omitempty"`
-	Children       []Link      `json:"children,omitempty"`
-	CryptAlgorithm string      `json:"-"`
+	Href       string      `json:"href"`
+	TypeLink   string      `json:"type,omitempty"`
+	Rel        []string    `json:"rel,omitempty"`
+	Height     int         `json:"height,omitempty"`
+	Width      int         `json:"width,omitempty"`
+	Title      string      `json:"title,omitempty"`
+	Properties *Properties `json:"properties,omitempty"`
+	Duration   string      `json:"duration,omitempty"`
+	Templated  bool        `json:"templated,omitempty"`
+	Children   []Link      `json:"children,omitempty"`
 }
 
 // PublicationCollection is used as an extension points for other collections in a Publication

--- a/parser/epub.go
+++ b/parser/epub.go
@@ -575,15 +575,36 @@ func fillCalibreSerieInfo(publication *models.Publication, book *epub.Book) {
 func fillEncryptionInfo(publication *models.Publication, book *epub.Book) {
 
 	for _, encInfo := range book.Encryption.EncryptedData {
+		encrypted := models.Encrypted{}
+		encrypted.Algorithm = encInfo.EncryptionMethod.Algorithm
+		if len(encInfo.EncryptionProperties) > 0 {
+			for _, prop := range encInfo.EncryptionProperties {
+				if prop.Compression.OriginalLength != "" {
+					encrypted.Size, _ = strconv.Atoi(prop.Compression.OriginalLength)
+					if prop.Compression.Method == "8" {
+						encrypted.Package = "deflate"
+					} else {
+						encrypted.Package = "none"
+					}
+				}
+			}
+		}
 		resURI := encInfo.CipherData.CipherReference.URI
+
 		for i, l := range publication.Resources {
 			if resURI == FilePath(*publication, l.Href) {
-				publication.Resources[i].CryptAlgorithm = encInfo.EncryptionMethod.Algorithm
+				if l.Properties == nil {
+					publication.Resources[i].Properties = &models.Properties{}
+				}
+				publication.Resources[i].Properties.Encrypted = &encrypted
 			}
 		}
 		for i, l := range publication.Spine {
 			if resURI == FilePath(*publication, l.Href) {
-				publication.Spine[i].CryptAlgorithm = encInfo.EncryptionMethod.Algorithm
+				if l.Properties == nil {
+					publication.Spine[i].Properties = &models.Properties{}
+				}
+				publication.Spine[i].Properties.Encrypted = &encrypted
 			}
 		}
 	}


### PR DESCRIPTION
Use the representation for encrypted like in this example 

{
  "href": "chapter1.xhtml",
  "type": "application/xhtml+xml",
  "properties": {
    "encrypted": {
      "scheme": "http://readium.org/2014/01/lcp",
      "profile": "http://readium.org/lcp/basic-profile",
      "algorithm": "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
      "package": "deflate",
      "size": 1234567
    }
  }
}