### PR TITLE
Rename 'Spine' to 'ReadingOrder'

### DIFF
--- a/fetcher/epub.go
+++ b/fetcher/epub.go
@@ -48,7 +48,7 @@ func FetchEpub(publication *models.Publication, publicationResource string) (io.
 		}
 	}
 
-	for _, linkRes := range publication.Spine {
+	for _, linkRes := range publication.ReadingOrder {
 		if publicationResource == linkRes.Href {
 			link = linkRes
 		}

--- a/fetcher/epub_dir.go
+++ b/fetcher/epub_dir.go
@@ -42,7 +42,7 @@ func FetchEpubDir(publication *models.Publication, publicationResource string) (
 		}
 	}
 
-	for _, linkRes := range publication.Spine {
+	for _, linkRes := range publication.ReadingOrder {
 		if publicationResource == linkRes.Href {
 			link = linkRes
 		}

--- a/main.go
+++ b/main.go
@@ -306,7 +306,7 @@ func getPublication(filename string, req *http.Request) (*models.Publication, er
 
 		publication, err := parser.Parse(string(filenamePath))
 		hasMediaOverlay := false
-		for _, l := range publication.Spine {
+		for _, l := range publication.ReadingOrder {
 			if l.Properties != nil && l.Properties.MediaOverlay != "" {
 				hasMediaOverlay = true
 			}

--- a/models/publication.go
+++ b/models/publication.go
@@ -10,18 +10,18 @@ import (
 
 // Publication Main structure for a publication
 type Publication struct {
-	Context   []string `json:"@context,omitempty"`
-	Metadata  Metadata `json:"metadata"`
-	Links     []Link   `json:"links"`
-	Spine     []Link   `json:"spine,omitempty"`
-	Resources []Link   `json:"resources,omitempty"` //Replaces the manifest but less redundant
-	TOC       []Link   `json:"toc,omitempty"`
-	PageList  []Link   `json:"page-list,omitempty"`
-	Landmarks []Link   `json:"landmarks,omitempty"`
-	LOI       []Link   `json:"loi,omitempty"` //List of illustrations
-	LOA       []Link   `json:"loa,omitempty"` //List of audio files
-	LOV       []Link   `json:"lov,omitempty"` //List of videos
-	LOT       []Link   `json:"lot,omitempty"` //List of tables
+	Context      []string `json:"@context,omitempty"`
+	Metadata     Metadata `json:"metadata"`
+	Links        []Link   `json:"links"`
+	ReadingOrder []Link   `json:"readingOrder,omitempty"`
+	Resources    []Link   `json:"resources,omitempty"` //Replaces the manifest but less redundant
+	TOC          []Link   `json:"toc,omitempty"`
+	PageList     []Link   `json:"page-list,omitempty"`
+	Landmarks    []Link   `json:"landmarks,omitempty"`
+	LOI          []Link   `json:"loi,omitempty"` //List of illustrations
+	LOA          []Link   `json:"loa,omitempty"` //List of audio files
+	LOV          []Link   `json:"lov,omitempty"` //List of videos
+	LOT          []Link   `json:"lot,omitempty"` //List of tables
 
 	OtherLinks       []Link                  `json:"-"` //Extension point for links that shouldn't show up in the manifest
 	OtherCollections []PublicationCollection `json:"-"` //Extension point for collections that shouldn't show up in the manifest
@@ -104,7 +104,7 @@ func (publication *Publication) searchLinkByRel(rel string) (Link, error) {
 		}
 	}
 
-	for _, item := range publication.Spine {
+	for _, item := range publication.ReadingOrder {
 		for _, spineRel := range item.Rel {
 			if spineRel == rel {
 				return item, nil
@@ -144,7 +144,7 @@ func (publication *Publication) AddLink(typeLink string, rel []string, url strin
 func (publication *Publication) FindAllMediaOverlay() []MediaOverlayNode {
 	var overlay []MediaOverlayNode
 
-	for _, l := range publication.Spine {
+	for _, l := range publication.ReadingOrder {
 		if len(l.MediaOverlays) > 0 {
 			for _, ov := range l.MediaOverlays {
 				overlay = append(overlay, ov)
@@ -159,7 +159,7 @@ func (publication *Publication) FindAllMediaOverlay() []MediaOverlayNode {
 func (publication *Publication) FindMediaOverlayByHref(href string) []MediaOverlayNode {
 	var overlay []MediaOverlayNode
 
-	for _, l := range publication.Spine {
+	for _, l := range publication.ReadingOrder {
 		if strings.Contains(l.Href, href) {
 			if len(l.MediaOverlays) > 0 {
 				for _, ov := range l.MediaOverlays {
@@ -288,9 +288,9 @@ func (link *Link) AddHrefAbsolute(href string, baseFile string) {
 //TransformLinkToFullURL concatenate a base url to all links
 func (publication *Publication) TransformLinkToFullURL(baseURL string) {
 
-	for i := range publication.Spine {
-		if !(strings.Contains(publication.Spine[i].Href, "http://") || strings.Contains(publication.Spine[i].Href, "https://")) {
-			publication.Spine[i].Href = baseURL + publication.Spine[i].Href
+	for i := range publication.ReadingOrder {
+		if !(strings.Contains(publication.ReadingOrder[i].Href, "http://") || strings.Contains(publication.ReadingOrder[i].Href, "https://")) {
+			publication.ReadingOrder[i].Href = baseURL + publication.ReadingOrder[i].Href
 		}
 	}
 

--- a/parser/cbz.go
+++ b/parser/cbz.go
@@ -37,7 +37,7 @@ func CbzParser(filePath string) (models.Publication, error) {
 		linkItem.TypeLink = getMediaTypeByName(f.Name)
 		linkItem.Href = f.Name
 		if linkItem.TypeLink != "" {
-			publication.Spine = append(publication.Spine, linkItem)
+			publication.ReadingOrder = append(publication.ReadingOrder, linkItem)
 		}
 		if f.Name == "ComicInfo.xml" {
 			fd, _ := f.Open()
@@ -121,7 +121,7 @@ func comicRackMetadata(publication *models.Publication, fd io.ReadCloser) {
 			if p.Type == "FrontCover" {
 				l.AddRel("cover")
 			}
-			l.Href = publication.Spine[p.Image].Href
+			l.Href = publication.ReadingOrder[p.Image].Href
 			if p.ImageHeight != 0 {
 				l.Height = p.ImageHeight
 			}

--- a/parser/epub.go
+++ b/parser/epub.go
@@ -139,7 +139,7 @@ func fillSpineAndResource(publication *models.Publication, book *epub.Epub) {
 			linkItem := findInManifestByID(book, item.IDref)
 
 			if linkItem.Href != "" {
-				publication.Spine = append(publication.Spine, linkItem)
+				publication.ReadingOrder = append(publication.ReadingOrder, linkItem)
 			}
 		}
 	}
@@ -159,7 +159,7 @@ func fillSpineAndResource(publication *models.Publication, book *epub.Epub) {
 }
 
 func findInSpineByHref(publication *models.Publication, href string) models.Link {
-	for _, l := range publication.Spine {
+	for _, l := range publication.ReadingOrder {
 		if l.Href == href {
 			return l
 		}
@@ -646,12 +646,12 @@ func fillEncryptionInfo(publication *models.Publication, book *epub.Epub) {
 				publication.Resources[i].Properties.Encrypted = &encrypted
 			}
 		}
-		for i, l := range publication.Spine {
+		for i, l := range publication.ReadingOrder {
 			if resURI == l.Href {
 				if l.Properties == nil {
-					publication.Spine[i].Properties = &models.Properties{}
+					publication.ReadingOrder[i].Properties = &models.Properties{}
 				}
-				publication.Spine[i].Properties.Encrypted = &encrypted
+				publication.ReadingOrder[i].Properties.Encrypted = &encrypted
 			}
 		}
 	}
@@ -912,9 +912,9 @@ func findLinKByHref(publication *models.Publication, href string, rootFile strin
 		return &models.Link{}
 	}
 
-	for i, l := range publication.Spine {
+	for i, l := range publication.ReadingOrder {
 		if l.Href == href {
-			return &publication.Spine[i]
+			return &publication.ReadingOrder[i]
 		}
 	}
 

--- a/parser/epub_test.go
+++ b/parser/epub_test.go
@@ -112,7 +112,7 @@ func TestPublication(t *testing.T) {
 				Convey("item no linear is not in spine", func() {
 					findItemInSpine := false
 
-					for _, it := range publication.Spine {
+					for _, it := range publication.ReadingOrder {
 						if it.Href == d.NoLinear {
 							findItemInSpine = true
 						}
@@ -176,7 +176,7 @@ func TestFixedPublication(t *testing.T) {
 			if d.linkLayout != "" {
 				Convey("There layout info in link", func() {
 					layout := false
-					for _, item := range publication.Spine {
+					for _, item := range publication.ReadingOrder {
 						if item.Properties != nil {
 							if item.Properties.Layout == d.linkLayout {
 								layout = true
@@ -191,7 +191,7 @@ func TestFixedPublication(t *testing.T) {
 			if d.linkOrientation != "" {
 				Convey("There orientation info in link", func() {
 					orientation := false
-					for _, item := range publication.Spine {
+					for _, item := range publication.ReadingOrder {
 						if item.Properties != nil {
 							if item.Properties.Orientation == d.linkOrientation {
 								orientation = true
@@ -205,7 +205,7 @@ func TestFixedPublication(t *testing.T) {
 			if d.linkSpread != "" {
 				Convey("There spread info in link", func() {
 					spread := false
-					for _, item := range publication.Spine {
+					for _, item := range publication.ReadingOrder {
 						if item.Properties != nil {
 							if item.Properties.Spread == d.linkSpread {
 								spread = true
@@ -219,7 +219,7 @@ func TestFixedPublication(t *testing.T) {
 			if d.linkPage != "" {
 				Convey("There page info in link", func() {
 					page := false
-					for _, item := range publication.Spine {
+					for _, item := range publication.ReadingOrder {
 						if item.Properties != nil {
 							if item.Properties.Page == d.linkPage {
 								page = true

--- a/searcher/epub.go
+++ b/searcher/epub.go
@@ -73,7 +73,7 @@ func indexEpub(publication models.Publication) {
 	//
 	// 		bleveIndex, _ = bleve.New(bleveIndexFile, indexMapping)
 	//
-	// 		for _, s := range publication.Spine {
+	// 		for _, s := range publication.ReadingOrder {
 	// 			reader, _, _ := fetcher.Fetch(publication, s.Href)
 	// 			buff, _ := ioutil.ReadAll(reader)
 	// 			fmt.Println("indexing " + s.Href)


### PR DESCRIPTION
Simple refactor of `Publication.Spine` to `Publication.ReadingOrder`
Took into account the `json:` encoding tag.

I used the refactor action from JetBrains GoLand for this.

Lightly tested with the included epubs. The change worked with no apparent issues.