### PR TITLE
Update models with Presentation Hints changes

### DIFF
--- a/models/metadata.go
+++ b/models/metadata.go
@@ -28,7 +28,7 @@ type Metadata struct {
 	PublicationDate *time.Time    `json:"published,omitempty"`
 	Description     string        `json:"description,omitempty"`
 	Direction       string        `json:"direction,omitempty"`
-	Rendition       *Properties   `json:"rendition,omitempty"`
+	Presentation    *Properties   `json:"presentation,omitempty"`
 	Source          string        `json:"source,omitempty"`
 	EpubType        []string      `json:"epub-type,omitempty"`
 	Rights          string        `json:"rights,omitempty"`

--- a/parser/epub.go
+++ b/parser/epub.go
@@ -107,7 +107,7 @@ func EpubParser(filePath string) (models.Publication, error) {
 	}
 
 	fillSpineAndResource(&publication, book)
-	addRendition(&publication, book)
+	addPresentation(&publication, book)
 	addCoverRel(&publication, book)
 	fillEncryptionInfo(&publication, book)
 
@@ -401,28 +401,28 @@ func addToLinkFromProperties(link *models.Link, propertiesString string) {
 	}
 }
 
-func addRendition(publication *models.Publication, book *epub.Epub) {
-	var rendition models.Properties
+func addPresentation(publication *models.Publication, book *epub.Epub) {
+	var presentation models.Properties
 
 	for _, meta := range book.Opf.Metadata.Meta {
 		switch meta.Property {
 		case "rendition:layout":
 			if meta.Data == "pre-paginated" {
-				rendition.Layout = "fixed"
+				presentation.Layout = "fixed"
 			} else if meta.Data == "reflowable" {
-				rendition.Layout = "reflowable"
+				presentation.Layout = "reflowable"
 			}
 		case "rendition:orientation":
-			rendition.Orientation = meta.Data
+			presentation.Orientation = meta.Data
 		case "rendition:spread":
-			rendition.Spread = meta.Data
+			presentation.Spread = meta.Data
 		case "rendition:flow":
-			rendition.Overflow = meta.Data
+			presentation.Overflow = meta.Data
 		}
 	}
 
-	if rendition.Layout != "" || rendition.Orientation != "" || rendition.Overflow != "" || rendition.Page != "" || rendition.Spread != "" {
-		publication.Metadata.Rendition = &rendition
+	if presentation.Layout != "" || presentation.Orientation != "" || presentation.Overflow != "" || presentation.Page != "" || presentation.Spread != "" {
+		publication.Metadata.Presentation = &presentation
 	}
 }
 


### PR DESCRIPTION
To conform to the latest [spec](https://readium.org/webpub-manifest/extensions/presentation.html):
- `Metadata.Rendition` is now `Metadata.Presentation`
- `Properties.Layout` is parsed per EPUB extension.

Schema files used for reference:
- https://github.com/readium/webpub-manifest/blob/master/schema/extensions/presentation/metadata.schema.json
- https://github.com/readium/webpub-manifest/blob/master/schema/extensions/presentation/properties.schema.json
- https://github.com/readium/webpub-manifest/blob/master/schema/extensions/epub/metadata.schema.json#L10
- https://github.com/readium/webpub-manifest/blob/master/schema/extensions/epub/properties.schema.json#L23